### PR TITLE
fixed same class definition load error in PHP 7.0.7

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -8,7 +8,7 @@ use yii;
 use CApplicationComponent;
 use CValidator;
 
-use MongoDB\Client;
+use MongoDB\Client as MongoClient;
 use MongoDB\Database as DriverDatabase;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Driver\ReadPreference;
@@ -157,7 +157,7 @@ class Client extends CApplicationComponent
 		// We copy this function to add the subdocument validator as a built in validator
 		CValidator::$builtInValidators['subdocument'] = 'sammaye\mongoyii\validators\SubdocumentValidator';
 
-		$this->client = new Client($this->uri, $this->options, $this->driverOptions);
+		$this->client = new MongoClient($this->uri, $this->options, $this->driverOptions);
 
 		if(!is_array($this->db)){
 			throw new Exception(Yii::t(

--- a/Cursor.php
+++ b/Cursor.php
@@ -2,7 +2,7 @@
 
 namespace sammaye\mongoyii;
 
-use MongoDB\Driver\Cursor;
+use MongoDB\Driver\Cursor as DriverCursor;
 
 use IteratorIterator;
 use Iterator;
@@ -29,19 +29,19 @@ class Cursor implements Iterator, Countable
 	 * @var string
 	 */
 	public $modelClass;
-	
+
 	/**
 	 * @var EMongoDocument
 	 */
 	public $model;
-	
+
 	public $partial;
-	
+
 	/**
 	 * @var array|MongoCursor|EMongoDocument[]
 	 */
 	private $cursor = array();
-	
+
 	/**
 	 * @var EMongoDocument
 	 */
@@ -62,11 +62,11 @@ class Cursor implements Iterator, Countable
 			$this->modelClass = get_class($modelClass);
 			$this->model = $modelClass;
 		}
-		
+
 		$it = new IteratorIterator($cursor);
 		$it->rewind();
 		$this->cursor = $it;
-		
+
 		if($options['partial']){
 			$this->partial = true;
 		}
@@ -83,16 +83,16 @@ class Cursor implements Iterator, Countable
 	 */
 	public function __call($method, $params = [])
 	{
-		if($this->cursor instanceof Cursor && method_exists($this->cursor, $method)){
+		if($this->cursor instanceof DriverCursor && method_exists($this->cursor, $method)){
 			return call_user_func_array(array($this->cursor, $method), $params);
 		}
 		throw new Exception(Yii::t(
-			'yii', 
-			'Call to undefined function {method} on the cursor', 
+			'yii',
+			'Call to undefined function {method} on the cursor',
 			['{method}' => $method]
 		));
 	}
-	
+
 	public function count()
 	{
 		throw new Exception('Count can no longer be done on the cursor!!');
@@ -121,8 +121,8 @@ class Cursor implements Iterator, Countable
 			return $this->current = $this->cursor->current();
 		}else{
 			return $this->current = $this->model->populateRecord(
-				$this->cursor->current(), 
-				true, 
+				$this->cursor->current(),
+				true,
 				$this->partial
 			);
 		}


### PR DESCRIPTION
in PHP 7.0.7, you'll get the fotal error like below  
`Fatal error: Cannot declare class sammaye\mongoyii\Client because the name is already in use in /data/www/vendor/sammaye/mongoyii-php7/Client.php on line 32"`

see more information:  https://bugs.php.net/bug.php?id=72159
