### PR TITLE
Fixing sorting.

### DIFF
--- a/Query.php
+++ b/Query.php
@@ -171,7 +171,7 @@ class Query extends CComponent
 			}
 		}
 		
-		$this->_sort = CMap::mergeArray($sort, $this->_sort);
+		$this->_sort = CMap::mergeArray($this->_sort, $sort);
 		return $this;
 	}
 


### PR DESCRIPTION
CMap::mergeArray - If each array has an element with the same string key value, the latter will overwrite the former