### PR TITLE
Fix deprecated arguments in mapreduce method

### DIFF
--- a/Document.php
+++ b/Document.php
@@ -1165,7 +1165,7 @@ class Document extends Model
 	 * @param array $options // All other options for input to the command
 	 * @return mixed
 	 */
-	public function mapreduce($map, $reduce, $finalize = null, $out, $query = array(), $options = array())
+	public function mapreduce($map, $reduce, $finalize = null, $out = ['inline' => 1], $query = [], $options = [])
 	{
 		return $this
 			->getDbConnection()


### PR DESCRIPTION
Good afternoon.
My team is using your library in our project. Now, we are starting to use PHP 8.0 and have a problem with deprecated method mapreduce in Document. I made a fix and it can be useful for other developers too.